### PR TITLE
chmod run.sh, remove trailing whitespace, tweak README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 Tuber-time Communications
-=====
+=========================
+
 [![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy?template=https://github.com/heroku/node-js-sample)
 [![Code Climate](https://codeclimate.com/repos/54ca6c63e30ba03b43001d83/badges/5f2928918fe9d60860c7/gpa.svg)](https://codeclimate.com/repos/54ca6c63e30ba03b43001d83/feed)
 

--- a/run.sh
+++ b/run.sh
@@ -27,7 +27,7 @@ install_nodejs () {
     if [ "$1" = "1" ]; then
         DOWNLOAD=1
     fi
-    
+
     if [ "$DOWNLOAD" = "0" ]; then
         log "Checking if node is installed..."
         node -v 2>&1 > /dev/null
@@ -72,12 +72,12 @@ install_nodejs () {
 
     FILENAME="`basename $NODEJS_URL`"
     BASENAME=${FILENAME%.tar.gz}
-    
+
     if [ ! -d $BASENAME ]; then
         log "Cannot find $BASENAME directory in $PWD"
         DOWNLOAD=1
     fi
-    
+
     if [ "$DOWNLOAD" = "1" ]; then
         log "Downloading node.js from $NODEJS_URL"
         curl $NODEJS_URL 2> /dev/null | tar zxf -
@@ -85,7 +85,7 @@ install_nodejs () {
     else
         log "Found node.js instance at $PWD/$BASENAME"
     fi
-    
+
     NODEJS_ROOT=$PWD/$BASENAME
 
     return 1
@@ -153,4 +153,3 @@ if [ "$SPAWN_BROWSER" = "1" ]; then
 fi
 
 fg
-


### PR DESCRIPTION
@dguido Starting off small—just testing out the `run.sh` script (works great!). Changes in this PR:
- `chmod +x run.sh`;
- Removed some trailing whitespace from `run.sh`;
- Minor adjustment to H1 `===` underline in README.

Is `run.sh` meant only for Heroku, or for running locally as well? Do you think we might be better served by moving this to a `scripts/` dir (possibly breaking it up in the process), then calling from `package.json` (_e.g._ `$ npm run install`) for local work and a `Procfile` for Heroku? Just some thoughts.
