### PR TITLE
Fix for inadvertently breaking this in new scope

### DIFF
--- a/public/js/clock.js
+++ b/public/js/clock.js
@@ -57,11 +57,12 @@ var Clock = {
      * @public
      */
     update: function() {
+        var _this = this;
         var date = new Date();
         var timeString = twoDigitNum(date.getHours()) + ':' + twoDigitNum(date.getMinutes());
         this.timeLabel.text(timeString);
         setTimeout(function() {
-            this.update();
+            _this.update();
         }, this.UPDATE_INTERVAL * 1000);
     }
 };


### PR DESCRIPTION
I read too quickly and stupidly didn't realize we were changing scope with the `obj` alias to `this`. There are a couple idiomatic ways to handle this; `var _this = this` is the one I prefer (though there are variants, such as `var self = this`, or using `Function.prototype.bind()`, which is sometimes more succinct but comes at a slight performance cost).

CC @dguido @yying 
