### PR TITLE
Minor changes to use SSL and provide a basic dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+# Very very simple Dockerfile for building and deploying tubertc
+# you'll need to customize this to add SSL etc. and you will need to place
+# this file in the parent directory of your checkout.
+FROM ubuntu:14.04
+RUN apt-get update && apt-get install -y curl ca-certificates && apt-get clean
+RUN mkdir -p /opt
+ADD tubertc /opt/tubertc
+WORKDIR /opt/tubertc
+#INSTALL THE SERVICE AND DEPENDENCIES
+RUN /opt/tubertc/run.sh -i
+CMD /opt/tubertc/run.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,15 @@
 # you'll need to customize this to add SSL etc. and you will need to place
 # this file in the parent directory of your checkout.
 FROM ubuntu:14.04
+# add the package rfc5766-turn-server to roll your own turn server
 RUN apt-get update && apt-get install -y curl ca-certificates && apt-get clean
 RUN mkdir -p /opt
 ADD tubertc /opt/tubertc
 WORKDIR /opt/tubertc
 #INSTALL THE SERVICE AND DEPENDENCIES
+# for SSL add certs below
+#ADD tubertc/settings.ssl.json /opt/tubertc/settings.json
+#ADD server.crt /opt/tubertc/server.crt
+#ADD server.key /opt/tubertc/server.key
 RUN /opt/tubertc/run.sh -i
 CMD /opt/tubertc/run.sh

--- a/settings.ssl.json
+++ b/settings.ssl.json
@@ -1,6 +1,6 @@
 {
-    "ssl": {"key": /opt/tubertc/server.key",
-            "cert": /opt/tubertc/server.crt"},
+    "ssl": {"key": "/opt/tubertc/server.key",
+            "cert": "/opt/tubertc/server.crt"},
     "port": 8080,
     "debug": true,
     "enableAudioMeter": true,

--- a/settings.ssl.json
+++ b/settings.ssl.json
@@ -1,0 +1,29 @@
+{
+    "ssl": {"key": /opt/tubertc/server.key",
+            "cert": /opt/tubertc/server.crt"},
+    "port": 8080,
+    "debug": true,
+    "enableAudioMeter": true,
+    "appIceServers": [
+        {
+            "url": "stun:stun.l.google.com:19302"
+        },
+        {
+            "url": "stun:stun.sipgate.net"
+        },
+        {
+            "url": "stun:217.10.68.152"
+        },
+        {
+            "url": "stun:stun.sipgate.net:10000"
+        },
+        {
+            "url": "stun:217.10.68.152:10000"
+        },
+        {
+            "url": "turn:104.236.58.250:3478?transport=tcp",
+            "username": "tuber",
+            "credential": "isuckatpasswords"
+        }
+    ]
+}


### PR DESCRIPTION
Updated  the run.sh script to use SSL for nodejs URLs & check sha1 sums. 

Made additional changes to simplify deployment via docker including:
 + Added a very basic dockerfile based on Ubuntu 14.04 LTS
 + Added an install only option to the run.sh script
 + Added a settings.ssl.json file to demonstrate what needs to be changed to add certificates.