### PR TITLE
Lock socket.io version to 2.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "open-easyrtc": "*",
         "express": "*",
         "nconf": "*",
-        "socket.io": "*",
+        "socket.io": "^2.0.0",
         "handlebars": "*"
     },
     "devDependencies": {


### PR DESCRIPTION
Doesn't work with later versions than this.